### PR TITLE
Log Immediately

### DIFF
--- a/src/ListenerLogger.cpp
+++ b/src/ListenerLogger.cpp
@@ -287,6 +287,7 @@ void UDPListenerLogger::write() {
     file_.write(last_data_received_, last_data_received_size_);
     file_.write(packet_delimiter.c_str(), std::strlen(packet_delimiter.c_str()));
 
+    file_.flush();
     memset(last_data_received_, 0, BUFF_SIZE);
     
     ++packets_written_;


### PR DESCRIPTION
Added fix for cpp/os to log incoming data packets immediately instead of waiting for the stream buffer to fill up to a certain number of bytes before writing.